### PR TITLE
defer attribute for external scripts

### DIFF
--- a/index.js
+++ b/index.js
@@ -476,7 +476,7 @@ HtmlWebpackPlugin.prototype.generateAssetTags = function (assets) {
       tagName: 'script',
       closeTag: true,
       attributes: {
-        type: 'module',
+        defer: 'defer',
         src: scriptPath
       }
     };


### PR DESCRIPTION
this is because "module" is not available in all browsers